### PR TITLE
Adds ZipFS to the existing solutions

### DIFF
--- a/docs/existing-solutions.md
+++ b/docs/existing-solutions.md
@@ -8,6 +8,7 @@ packaging Node.js applications as standalone executables.
 |------------|--------------|-----------------------------------------|------------------|
 | pkg        | Vercel       | https://github.com/vercel/pkg           | @jesec           |
 | boxednode  | MongoDB      | https://github.com/mongodb-js/boxednode | @addaleax        |
+| ZipFS      | Yarn         | https://github.com/yarnpkg/berry        | @arcanis         |
 | nexe       | -            | https://github.com/nexe/nexe            | N/A              |
 
 Virtual File System Implementations

--- a/docs/existing-solutions.md
+++ b/docs/existing-solutions.md
@@ -8,19 +8,20 @@ packaging Node.js applications as standalone executables.
 |------------|--------------|-----------------------------------------|------------------|
 | pkg        | Vercel       | https://github.com/vercel/pkg           | @jesec           |
 | boxednode  | MongoDB      | https://github.com/mongodb-js/boxednode | @addaleax        |
-| ZipFS      | Yarn         | https://github.com/yarnpkg/berry        | @arcanis         |
 | nexe       | -            | https://github.com/nexe/nexe            | N/A              |
 
 Virtual File System Implementations
 -----------------------------------
 
-| Name | Project  | Reference                                                                                          | Point of Contact |
-|------|----------|----------------------------------------------------------------------------------------------------|------------------|
-| ASAR | Electron | <ul><li>[ASAR format]</li><li>[monkey patching of `fs` in Electron to read from an ASAR]</li></ul> | [`@zcbenz`]      |
+| Name  | Project  | Reference                                                                                          | Point of Contact |
+|-------|----------|----------------------------------------------------------------------------------------------------|------------------|
+| ASAR  | Electron | <ul><li>[ASAR format]</li><li>[monkey patching of `fs` in Electron to read from an ASAR]</li></ul> | [`@zcbenz`]      |
+| ZipFS | Yarn     | [ZipFS]                                                                                            | @arcanis         |
 
 [ASAR format]: https://github.com/electron/asar
 [`@zcbenz`]: https://github.com/zcbenz
 [monkey patching of `fs` in Electron to read from an ASAR]: https://github.com/electron/electron/blob/06a00b74e817a61f20e2734d50d8eb7bc9b099f6/lib/asar/fs-wrapper.ts
+[ZipFS]: https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-fslib/sources/ZipFS.ts
 
 Miscellaneous Related Tooling
 -----------------------------


### PR DESCRIPTION
Yarn has been using a filesystem layer over Node for all PnP applications for a few years now. It's well-maintained, used in production, covered by tests (although there's no way to run the Node.js test suite over it, which is too bad), and supports almost all Node features (including fds, buffer paths, file watching, ...).

We use it to package every dependency, including those with bin entries (for instance, when you run `yarn eslint`, it runs it straight from the zip archive thanks to this layer).

Here's what the implementation looks like:
https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-fslib/sources/ZipFS.ts