### PR TITLE
Change branch name from master to main in link

### DIFF
--- a/docs/existing-solutions.md
+++ b/docs/existing-solutions.md
@@ -11,4 +11,4 @@ packaging Node.js applications as standalone executables.
 | nexe       | -            | https://github.com/nexe/nexe            | N/A              |
 
 Did we miss any or got any details wrong? [Help us out by sending a
-PR!](https://github.com/nodejs/single-executable/edit/master/docs/existing-solutions.md)
+PR!](https://github.com/nodejs/single-executable/edit/main/docs/existing-solutions.md)


### PR DESCRIPTION
I had renamed the default branch from master to main, so the link
doesn't work now.

Signed-off-by: Darshan Sen <raisinten@gmail.com>