### PR TITLE
Start documenting production Node.js CLIs that could use the new SEAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Table of Contents
 -----------------
 
 - [Existing SEA Solutions](./docs/existing-solutions.md)
+- [Production Node.js CLIs](./docs/production-nodejs-clis.md)
 
 Blog
 ----

--- a/docs/production-nodejs-clis.md
+++ b/docs/production-nodejs-clis.md
@@ -3,8 +3,8 @@ Production Node.js CLIs
 
 This document aims to list every known production-ready Node.js CLI that would
 be a good fit for using the SEA solutions discussed in this repository. We can
-use this list to test our ideas against and make sure we are heading in the
-right direction.
+use this list to test our ideas against (potentially using [citgm][]) and make
+sure we are heading in the right direction.
 
 | Name                                   | Organization | Point of Contact        |
 |----------------------------------------|--------------|-------------------------|
@@ -15,3 +15,5 @@ right direction.
 
 Did we miss any or got any details wrong? [Help us out by sending a
 PR!](https://github.com/nodejs/single-executable/edit/main/docs/production-nodejs-clis.md)
+
+[citgm]: https://github.com/nodejs/citgm

--- a/docs/production-nodejs-clis.md
+++ b/docs/production-nodejs-clis.md
@@ -1,0 +1,17 @@
+Production Node.js CLIs
+=======================
+
+This document aims to list every known production-ready Node.js CLI that would
+be a good fit for using the SEA solutions discussed in this repository. We can
+use this list to test our ideas against and make sure we are heading in the
+right direction.
+
+| Name                                   | Organization | Point of Contact        |
+|----------------------------------------|--------------|-------------------------|
+| [Playwright Driver][playwright-driver] | Microsoft    | [@mxschmitt][mxschmitt] | 
+
+[playwright-driver]: https://github.com/microsoft/playwright/blob/16ab54db441e268abbfdf49dc05ec44271706cad/utils/build/build-playwright-driver.sh
+[mxschmitt]: https://github.com/mxschmitt
+
+Did we miss any or got any details wrong? [Help us out by sending a
+PR!](https://github.com/nodejs/single-executable/edit/main/docs/production-nodejs-clis.md)


### PR DESCRIPTION
This is extracted from one of our GitHub Discussions. I think its a
great idea to start collecting a list of production-ready Node.js CLIs
that would use our SEA approach in the future.

See: https://github.com/nodejs/single-executable/discussions/24
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
